### PR TITLE
Implement clean URLs for entire website

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -45,11 +45,11 @@
         </div>
 
         <nav class="main-navigation" aria-label="主要導覽">
-          <a href="index.html" class="nav-link">首頁</a>
-          <a href="social-board.html" class="nav-link">社群看板</a>
-          <a href="support.html" class="nav-link">支援</a>
-          <a href="tos.html" class="nav-link">服務條款</a>
-          <a href="privacy-policies.html" class="nav-link">隱私政策</a>
+          <a href="/" class="nav-link">首頁</a>
+          <a href="/social-board/" class="nav-link">社群看板</a>
+          <a href="/support/" class="nav-link">支援</a>
+          <a href="/tos/" class="nav-link">服務條款</a>
+          <a href="/privacy-policies/" class="nav-link">隱私政策</a>
         </nav>
 
         <div class="header-actions">
@@ -88,10 +88,10 @@
 
         <!-- Action Buttons -->
         <div style="margin-bottom: 50px;">
-          <a href="index.html" class="btn btn-primary" style="margin: 0 10px;">
+          <a href="/" class="btn btn-primary" style="margin: 0 10px;">
             🏠 回到首頁
           </a>
-          <a href="support.html" class="btn btn-secondary" style="margin: 0 10px;">
+          <a href="/support/" class="btn btn-secondary" style="margin: 0 10px;">
             💬 聯絡支援
           </a>
         </div>
@@ -100,11 +100,11 @@
         <div>
           <h3 style="color: #ffffff; margin-bottom: 20px; font-size: 24px;">您可能在尋找：</h3>
           <div class="grid-4" style="max-width: 500px; margin: 0 auto;">
-            <a href="social-board.html" style="display: block; padding: 20px; text-decoration: none; color: #ffffff; background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.2); border-radius: 12px; margin: 8px; transition: all 0.3s ease; backdrop-filter: blur(10px);" onmouseover="this.style.background='rgba(255, 255, 255, 0.2)'; this.style.transform='translateY(-2px)'" onmouseout="this.style.background='rgba(255, 255, 255, 0.1)'; this.style.transform='translateY(0)'">
+            <a href="/social-board/" style="display: block; padding: 20px; text-decoration: none; color: #ffffff; background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.2); border-radius: 12px; margin: 8px; transition: all 0.3s ease; backdrop-filter: blur(10px);" onmouseover="this.style.background='rgba(255, 255, 255, 0.2)'; this.style.transform='translateY(-2px)'" onmouseout="this.style.background='rgba(255, 255, 255, 0.1)'; this.style.transform='translateY(0)'">
               <div style="font-size: 28px; margin-bottom: 8px;">👥</div>
               <div style="font-weight: 500;">社群看板</div>
             </a>
-            <a href="support.html" style="display: block; padding: 20px; text-decoration: none; color: #ffffff; background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.2); border-radius: 12px; margin: 8px; transition: all 0.3s ease; backdrop-filter: blur(10px);" onmouseover="this.style.background='rgba(255, 255, 255, 0.2)'; this.style.transform='translateY(-2px)'" onmouseout="this.style.background='rgba(255, 255, 255, 0.1)'; this.style.transform='translateY(0)'">
+            <a href="/support/" style="display: block; padding: 20px; text-decoration: none; color: #ffffff; background: rgba(255, 255, 255, 0.1); border: 1px solid rgba(255, 255, 255, 0.2); border-radius: 12px; margin: 8px; transition: all 0.3s ease; backdrop-filter: blur(10px);" onmouseover="this.style.background='rgba(255, 255, 255, 0.2)'; this.style.transform='translateY(-2px)'" onmouseout="this.style.background='rgba(255, 255, 255, 0.1)'; this.style.transform='translateY(0)'">
               <div style="font-size: 28px; margin-bottom: 8px;">💬</div>
               <div style="font-weight: 500;">客服支援</div>
             </a>
@@ -141,16 +141,16 @@
           <div class="link-group">
             <h3 class="group-title">應用程式</h3>
             <ul class="link-list">
-              <li><a href="index.html">首頁</a></li>
+              <li><a href="/">首頁</a></li>
               <li><a href="https://apps.apple.com/tw/app/dailyval/id1637782901">下載</a></li>
-              <li><a href="support.html">版本更新</a></li>
+              <li><a href="/support/">版本更新</a></li>
             </ul>
           </div>
 
           <div class="link-group">
             <h3 class="group-title">支援</h3>
             <ul class="link-list">
-              <li><a href="support.html">幫助中心</a></li>
+              <li><a href="/support/">幫助中心</a></li>
               <li><a href="mailto:support@dailyval.com">聯絡我們</a></li>
               <li><a href="https://www.instagram.com/dailyval_official/">社群</a></li>
             </ul>
@@ -159,8 +159,8 @@
           <div class="link-group">
             <h3 class="group-title">法律</h3>
             <ul class="link-list">
-              <li><a href="tos.html">服務條款</a></li>
-              <li><a href="privacy-policies.html">隱私政策</a></li>
+              <li><a href="/tos/">服務條款</a></li>
+              <li><a href="/privacy-policies/">隱私政策</a></li>
             </ul>
           </div>
         </div>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,2 +1,15 @@
 include:
   - .well-known
+
+# Clean URLs configuration
+permalink: pretty
+plugins:
+  - jekyll-optional-front-matter
+
+# Default front matter for all HTML files
+defaults:
+  - scope:
+      path: ""
+      type: "pages"
+    values:
+      permalink: /:basename/

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,3 +1,6 @@
+---
+permalink: /
+---
 <!DOCTYPE html>
 <html lang="zh-Hant">
 
@@ -68,11 +71,11 @@
         </div>
 
         <nav class="main-navigation" aria-label="主要導覽">
-          <a href="index.html" class="nav-link" aria-current="page">首頁</a>
-          <a href="social-board.html" class="nav-link">社群看板</a>
-          <a href="support.html" class="nav-link">支援</a>
-          <a href="tos.html" class="nav-link">服務條款</a>
-          <a href="privacy-policies.html" class="nav-link">隱私政策</a>
+          <a href="/" class="nav-link" aria-current="page">首頁</a>
+          <a href="/social-board/" class="nav-link">社群看板</a>
+          <a href="/support/" class="nav-link">支援</a>
+          <a href="/tos/" class="nav-link">服務條款</a>
+          <a href="/privacy-policies/" class="nav-link">隱私政策</a>
         </nav>
 
         <div class="header-actions">
@@ -299,14 +302,14 @@
             <ul class="link-list">
               <li><a href="#features">功能介紹</a></li>
               <li><a href="https://apps.apple.com/tw/app/dailyval/id1637782901">下載</a></li>
-              <li><a href="support.html">版本更新</a></li>
+              <li><a href="/support/">版本更新</a></li>
             </ul>
           </div>
 
           <div class="link-group">
             <h3 class="group-title">支援</h3>
             <ul class="link-list">
-              <li><a href="support.html">幫助中心</a></li>
+              <li><a href="/support/">幫助中心</a></li>
               <li><a href="mailto:support@dailyval.com">聯絡我們</a></li>
               <li><a href="https://www.instagram.com/dailyval_official/">社群</a></li>
             </ul>
@@ -315,8 +318,8 @@
           <div class="link-group">
             <h3 class="group-title">法律</h3>
             <ul class="link-list">
-              <li><a href="tos.html">服務條款</a></li>
-              <li><a href="privacy-policies.html">隱私政策</a></li>
+              <li><a href="/tos/">服務條款</a></li>
+              <li><a href="/privacy-policies/">隱私政策</a></li>
             </ul>
           </div>
         </div>

--- a/docs/privacy-policies.html
+++ b/docs/privacy-policies.html
@@ -1,3 +1,6 @@
+---
+permalink: /privacy-policies/
+---
 <!DOCTYPE html>
 <html lang="zh-Hant">
 <head>
@@ -53,11 +56,11 @@
         </div>
 
         <nav class="main-navigation" aria-label="主要導覽">
-          <a href="index.html" class="nav-link">首頁</a>
-          <a href="social-board.html" class="nav-link">社群看板</a>
-          <a href="support.html" class="nav-link">支援</a>
-          <a href="tos.html" class="nav-link">服務條款</a>
-          <a href="privacy-policies.html" class="nav-link" aria-current="page">隱私政策</a>
+          <a href="/" class="nav-link">首頁</a>
+          <a href="/social-board/" class="nav-link">社群看板</a>
+          <a href="/support/" class="nav-link">支援</a>
+          <a href="/tos/" class="nav-link">服務條款</a>
+          <a href="/privacy-policies/" class="nav-link" aria-current="page">隱私政策</a>
         </nav>
 
         <div class="header-actions">
@@ -278,16 +281,16 @@
           <div class="link-group">
             <h3 class="group-title">應用程式</h3>
             <ul class="link-list">
-              <li><a href="index.html#features">功能介紹</a></li>
+              <li><a href="/#features">功能介紹</a></li>
               <li><a href="https://apps.apple.com/tw/app/dailyval/id1637782901">下載</a></li>
-              <li><a href="support.html">版本更新</a></li>
+              <li><a href="/support/">版本更新</a></li>
             </ul>
           </div>
 
           <div class="link-group">
             <h3 class="group-title">支援</h3>
             <ul class="link-list">
-              <li><a href="support.html">幫助中心</a></li>
+              <li><a href="/support/">幫助中心</a></li>
               <li><a href="mailto:support@dailyval.com">聯絡我們</a></li>
               <li><a href="https://www.instagram.com/dailyval_official/">社群</a></li>
             </ul>
@@ -296,8 +299,8 @@
           <div class="link-group">
             <h3 class="group-title">法律</h3>
             <ul class="link-list">
-              <li><a href="tos.html">服務條款</a></li>
-              <li><a href="privacy-policies.html">隱私政策</a></li>
+              <li><a href="/tos/">服務條款</a></li>
+              <li><a href="/privacy-policies/">隱私政策</a></li>
             </ul>
           </div>
         </div>

--- a/docs/social-board.html
+++ b/docs/social-board.html
@@ -1,3 +1,6 @@
+---
+permalink: /social-board/
+---
 <!DOCTYPE html>
 <html lang="zh-Hant">
 
@@ -46,11 +49,11 @@
         </div>
 
         <nav class="main-navigation" aria-label="主要導覽">
-          <a href="index.html" class="nav-link">首頁</a>
-          <a href="social-board.html" class="nav-link" aria-current="page">社群看板</a>
-          <a href="support.html" class="nav-link">支援</a>
-          <a href="tos.html" class="nav-link">服務條款</a>
-          <a href="privacy-policies.html" class="nav-link">隱私政策</a>
+          <a href="/" class="nav-link">首頁</a>
+          <a href="/social-board/" class="nav-link" aria-current="page">社群看板</a>
+          <a href="/support/" class="nav-link">支援</a>
+          <a href="/tos/" class="nav-link">服務條款</a>
+          <a href="/privacy-policies/" class="nav-link">隱私政策</a>
         </nav>
 
         <div class="header-actions">
@@ -147,16 +150,16 @@
           <div class="link-group">
             <h3 class="group-title">應用程式</h3>
             <ul class="link-list">
-              <li><a href="index.html#features">功能介紹</a></li>
+              <li><a href="/#features">功能介紹</a></li>
               <li><a href="https://apps.apple.com/tw/app/dailyval/id1637782901">下載</a></li>
-              <li><a href="support.html">版本更新</a></li>
+              <li><a href="/support/">版本更新</a></li>
             </ul>
           </div>
 
           <div class="link-group">
             <h3 class="group-title">支援</h3>
             <ul class="link-list">
-              <li><a href="support.html">幫助中心</a></li>
+              <li><a href="/support/">幫助中心</a></li>
               <li><a href="mailto:support@dailyval.com">聯絡我們</a></li>
               <li><a href="https://www.instagram.com/dailyval_official/">社群</a></li>
             </ul>
@@ -165,8 +168,8 @@
           <div class="link-group">
             <h3 class="group-title">法律</h3>
             <ul class="link-list">
-              <li><a href="tos.html">服務條款</a></li>
-              <li><a href="privacy-policies.html">隱私政策</a></li>
+              <li><a href="/tos/">服務條款</a></li>
+              <li><a href="/privacy-policies/">隱私政策</a></li>
             </ul>
           </div>
         </div>

--- a/docs/support.html
+++ b/docs/support.html
@@ -1,3 +1,6 @@
+---
+permalink: /support/
+---
 <!DOCTYPE html>
 <html lang="zh-Hant">
 
@@ -46,11 +49,11 @@
         </div>
 
         <nav class="main-navigation" aria-label="主要導覽">
-          <a href="index.html" class="nav-link">首頁</a>
-          <a href="social-board.html" class="nav-link">社群看板</a>
-          <a href="support.html" class="nav-link" aria-current="page">支援</a>
-          <a href="tos.html" class="nav-link">服務條款</a>
-          <a href="privacy-policies.html" class="nav-link">隱私政策</a>
+          <a href="/" class="nav-link">首頁</a>
+          <a href="/social-board/" class="nav-link">社群看板</a>
+          <a href="/support/" class="nav-link" aria-current="page">支援</a>
+          <a href="/tos/" class="nav-link">服務條款</a>
+          <a href="/privacy-policies/" class="nav-link">隱私政策</a>
         </nav>
 
         <div class="header-actions">
@@ -248,16 +251,16 @@
           <div class="link-group">
             <h3 class="group-title">應用程式</h3>
             <ul class="link-list">
-              <li><a href="index.html#features">功能介紹</a></li>
+              <li><a href="/#features">功能介紹</a></li>
               <li><a href="https://apps.apple.com/tw/app/dailyval/id1637782901">下載</a></li>
-              <li><a href="support.html">版本更新</a></li>
+              <li><a href="/support/">版本更新</a></li>
             </ul>
           </div>
 
           <div class="link-group">
             <h3 class="group-title">支援</h3>
             <ul class="link-list">
-              <li><a href="support.html">幫助中心</a></li>
+              <li><a href="/support/">幫助中心</a></li>
               <li><a href="mailto:support@dailyval.com">聯絡我們</a></li>
               <li><a href="https://www.instagram.com/dailyval_official/">社群</a></li>
             </ul>
@@ -266,8 +269,8 @@
           <div class="link-group">
             <h3 class="group-title">法律</h3>
             <ul class="link-list">
-              <li><a href="tos.html">服務條款</a></li>
-              <li><a href="privacy-policies.html">隱私政策</a></li>
+              <li><a href="/tos/">服務條款</a></li>
+              <li><a href="/privacy-policies/">隱私政策</a></li>
             </ul>
           </div>
         </div>

--- a/docs/tos.html
+++ b/docs/tos.html
@@ -1,4 +1,7 @@
 
+---
+permalink: /tos/
+---
 <!DOCTYPE html>
 <html lang="zh-Hant">
 <head>
@@ -54,11 +57,11 @@
         </div>
 
         <nav class="main-navigation" aria-label="主要導覽">
-          <a href="index.html" class="nav-link">首頁</a>
-          <a href="social-board.html" class="nav-link">社群看板</a>
-          <a href="support.html" class="nav-link">支援</a>
-          <a href="tos.html" class="nav-link" aria-current="page">服務條款</a>
-          <a href="privacy-policies.html" class="nav-link">隱私政策</a>
+          <a href="/" class="nav-link">首頁</a>
+          <a href="/social-board/" class="nav-link">社群看板</a>
+          <a href="/support/" class="nav-link">支援</a>
+          <a href="/tos/" class="nav-link" aria-current="page">服務條款</a>
+          <a href="/privacy-policies/" class="nav-link">隱私政策</a>
         </nav>
 
         <div class="header-actions">
@@ -279,16 +282,16 @@
           <div class="link-group">
             <h3 class="group-title">應用程式</h3>
             <ul class="link-list">
-              <li><a href="index.html#features">功能介紹</a></li>
+              <li><a href="/#features">功能介紹</a></li>
               <li><a href="https://apps.apple.com/tw/app/dailyval/id1637782901">下載</a></li>
-              <li><a href="support.html">版本更新</a></li>
+              <li><a href="/support/">版本更新</a></li>
             </ul>
           </div>
 
           <div class="link-group">
             <h3 class="group-title">支援</h3>
             <ul class="link-list">
-              <li><a href="support.html">幫助中心</a></li>
+              <li><a href="/support/">幫助中心</a></li>
               <li><a href="mailto:support@dailyval.com">聯絡我們</a></li>
               <li><a href="https://www.instagram.com/dailyval_official/">社群</a></li>
             </ul>
@@ -297,8 +300,8 @@
           <div class="link-group">
             <h3 class="group-title">法律</h3>
             <ul class="link-list">
-              <li><a href="tos.html">服務條款</a></li>
-              <li><a href="privacy-policies.html">隱私政策</a></li>
+              <li><a href="/tos/">服務條款</a></li>
+              <li><a href="/privacy-policies/">隱私政策</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
- Configure Jekyll for clean URLs in _config.yml with permalink: pretty
- Add Jekyll front matter with custom permalinks to all HTML pages
- Update all internal navigation links to use clean URL structure
- Remove .html extensions from all href attributes across the site
- Configure URL structure: / /support/ /social-board/ /tos/ /privacy-policies/

This eliminates .html extensions from the address bar for better UX and SEO.

🤖 Generated with [Claude Code](https://claude.ai/code)