### PR TITLE
Fix broken CSS and JS paths caused by clean URLs

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://unicons.iconscout.com/release/v4.0.8/css/line.css">
-  <link rel="stylesheet" href="style.css">
-  <script src="script.js" defer></script>
+  <link rel="stylesheet" href="/style.css">
+  <script src="/script.js" defer></script>
   <!-- SEO Meta Tags -->
   <title>頁面未找到 - DailyVal | 特戰英豪社群 APP</title>
   <meta name="description" content="抱歉，您所尋找的頁面不存在。回到 DailyVal 首頁繼續探索特戰英豪社群功能。">
@@ -36,7 +36,7 @@
       <div class="header-container">
         <div class="header-brand">
           <a href="/" class="header-brand">
-            <img src="images/app icon.png" alt="DailyVal" class="brand-icon">
+            <img src="/images/app icon.png" alt="DailyVal" class="brand-icon">
             <div class="brand-text">
               <span class="brand-name">DailyVal</span>
               <span class="brand-tagline">每日特戰英豪</span>
@@ -121,7 +121,7 @@
       <div class="footer-content">
         <div class="footer-brand">
           <div class="brand-logo">
-            <img src="images/app icon.png" alt="DailyVal">
+            <img src="/images/app icon.png" alt="DailyVal">
             <span class="brand-name">DailyVal</span>
           </div>
           <p class="brand-description">

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,8 +8,8 @@ permalink: /
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://unicons.iconscout.com/release/v4.0.8/css/line.css">
-  <link rel="stylesheet" href="style.css">
-  <script src="script.js" defer></script>
+  <link rel="stylesheet" href="/style.css">
+  <script src="/script.js" defer></script>
 
   <!-- SEO Meta Tags -->
   <title>DailyVal - 超過 80 萬玩家的特戰英豪專用社群 APP | 戰績查詢、造型分享、每日商城</title>
@@ -62,7 +62,7 @@ permalink: /
       <div class="header-container">
         <div class="header-brand">
           <a href="/" class="header-brand">
-            <img src="images/app icon.png" alt="DailyVal" class="brand-icon">
+            <img src="/images/app icon.png" alt="DailyVal" class="brand-icon">
             <div class="brand-text">
               <span class="brand-name">DailyVal</span>
               <span class="brand-tagline">每日特戰英豪</span>
@@ -142,7 +142,7 @@ permalink: /
 
           <div class="hero-visual">
             <div class="phone-mockup">
-              <img src="images/hero.png" alt="DailyVal 應用程式介面" class="hero-image">
+              <img src="/images/hero.png" alt="DailyVal 應用程式介面" class="hero-image">
               <div class="floating-elements">
                 <div class="feature-highlight feature-1">社群互動</div>
                 <div class="feature-highlight feature-2">即時數據</div>
@@ -172,7 +172,7 @@ permalink: /
               即時追蹤商城更新，不錯過任何心愛的造型與武器外觀
             </p>
             <div class="feature-preview">
-              <img src="images/1.png" alt="每日商城功能預覽">
+              <img src="/images/1.png" alt="每日商城功能預覽">
             </div>
           </div>
 
@@ -183,7 +183,7 @@ permalink: /
               與 80 萬玩家分享戰績、討論策略，在亞洲最活躍的 Valorant 社群中建立你的聲望
             </p>
             <div class="feature-preview">
-              <img src="images/2.png" alt="社群看板功能預覽">
+              <img src="/images/2.png" alt="社群看板功能預覽">
             </div>
           </div>
 
@@ -194,7 +194,7 @@ permalink: /
               管理你的武器收藏，展示獨特的造型搭配
             </p>
             <div class="feature-preview">
-              <img src="images/3.png" alt="個人裝備功能預覽">
+              <img src="/images/3.png" alt="個人裝備功能預覽">
             </div>
           </div>
 
@@ -205,7 +205,7 @@ permalink: /
               詳細的數據分析，幫助你了解並提升遊戲表現
             </p>
             <div class="feature-preview">
-              <img src="images/5.png" alt="戰績追蹤功能預覽">
+              <img src="/images/5.png" alt="戰績追蹤功能預覽">
             </div>
           </div>
 
@@ -216,7 +216,7 @@ permalink: /
               實時監控進行中的比賽，掌握最新戰況
             </p>
             <div class="feature-preview">
-              <img src="images/6.png" alt="即時對戰功能預覽">
+              <img src="/images/6.png" alt="即時對戰功能預覽">
             </div>
           </div>
 
@@ -227,7 +227,7 @@ permalink: /
               客製化你的應用程式體驗，調整通知、主題和個人偏好設定
             </p>
             <div class="feature-preview">
-              <img src="images/4.png" alt="個人設定功能預覽">
+              <img src="/images/4.png" alt="個人設定功能預覽">
             </div>
           </div>
 
@@ -238,7 +238,7 @@ permalink: /
               深入分析每一回合的表現，找出改進空間
             </p>
             <div class="feature-preview">
-              <img src="images/7.png" alt="回合詳情功能預覽">
+              <img src="/images/7.png" alt="回合詳情功能預覽">
             </div>
           </div>
 
@@ -249,7 +249,7 @@ permalink: /
               即使不在遊戲中也能提前選擇特務，為團隊戰略做好準備
             </p>
             <div class="feature-preview">
-              <img src="images/8.png" alt="遠端選角功能預覽">
+              <img src="/images/8.png" alt="遠端選角功能預覽">
             </div>
           </div>
         </div>
@@ -280,7 +280,7 @@ permalink: /
       <div class="footer-content">
         <div class="footer-brand">
           <div class="brand-logo">
-            <img src="images/app icon.png" alt="DailyVal">
+            <img src="/images/app icon.png" alt="DailyVal">
             <span class="brand-name">DailyVal</span>
           </div>
           <p class="brand-description">

--- a/docs/privacy-policies.html
+++ b/docs/privacy-policies.html
@@ -7,8 +7,8 @@ permalink: /privacy-policies/
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://unicons.iconscout.com/release/v4.0.8/css/line.css">
-  <link rel="stylesheet" href="style.css">
-  <script src="script.js" defer></script>
+  <link rel="stylesheet" href="/style.css">
+  <script src="/script.js" defer></script>
 
   <!-- SEO Meta Tags -->
   <title>隱私政策 - DailyVal | 特戰英豪社群 APP</title>
@@ -47,7 +47,7 @@ permalink: /privacy-policies/
       <div class="header-container">
         <div class="header-brand">
           <a href="/" class="header-brand">
-            <img src="images/app icon.png" alt="DailyVal" class="brand-icon">
+            <img src="/images/app icon.png" alt="DailyVal" class="brand-icon">
             <div class="brand-text">
               <span class="brand-name">DailyVal</span>
               <span class="brand-tagline">每日特戰英豪</span>
@@ -261,7 +261,7 @@ permalink: /privacy-policies/
       <div class="footer-content">
         <div class="footer-brand">
           <div class="brand-logo">
-            <img src="images/app icon.png" alt="DailyVal">
+            <img src="/images/app icon.png" alt="DailyVal">
             <span class="brand-name">DailyVal</span>
           </div>
           <p class="brand-description">

--- a/docs/social-board.html
+++ b/docs/social-board.html
@@ -8,8 +8,8 @@ permalink: /social-board/
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://unicons.iconscout.com/release/v4.0.8/css/line.css">
-  <link rel="stylesheet" href="style.css">
-  <script src="script.js" defer></script>
+  <link rel="stylesheet" href="/style.css">
+  <script src="/script.js" defer></script>
 
   <!-- SEO Meta Tags -->
   <title>DailyVal 社群看板 | 80 萬玩家的特戰英豪社群互動平台</title>
@@ -40,7 +40,7 @@ permalink: /social-board/
       <div class="header-container">
         <div class="header-brand">
           <a href="/" class="header-brand">
-            <img src="images/app icon.png" alt="DailyVal" class="brand-icon">
+            <img src="/images/app icon.png" alt="DailyVal" class="brand-icon">
             <div class="brand-text">
               <span class="brand-name">DailyVal</span>
               <span class="brand-tagline">社群看板</span>
@@ -130,7 +130,7 @@ permalink: /social-board/
       <div class="footer-content">
         <div class="footer-brand">
           <div class="brand-logo">
-            <img src="images/app icon.png" alt="DailyVal">
+            <img src="/images/app icon.png" alt="DailyVal">
             <span class="brand-name">DailyVal</span>
           </div>
           <p class="brand-description">

--- a/docs/support.html
+++ b/docs/support.html
@@ -8,8 +8,8 @@ permalink: /support/
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://unicons.iconscout.com/release/v4.0.8/css/line.css">
-  <link rel="stylesheet" href="style.css">
-  <script src="script.js" defer></script>
+  <link rel="stylesheet" href="/style.css">
+  <script src="/script.js" defer></script>
 
   <!-- SEO Meta Tags -->
   <title>DailyVal 支援中心 | 為 80 萬用戶提供專業客戶服務</title>
@@ -40,7 +40,7 @@ permalink: /support/
       <div class="header-container">
         <div class="header-brand">
           <a href="/" class="header-brand">
-            <img src="images/app icon.png" alt="DailyVal" class="brand-icon">
+            <img src="/images/app icon.png" alt="DailyVal" class="brand-icon">
             <div class="brand-text">
               <span class="brand-name">DailyVal</span>
               <span class="brand-tagline">支援中心</span>
@@ -231,7 +231,7 @@ permalink: /support/
       <div class="footer-content">
         <div class="footer-brand">
           <div class="brand-logo">
-            <img src="images/app icon.png" alt="DailyVal">
+            <img src="/images/app icon.png" alt="DailyVal">
             <span class="brand-name">DailyVal</span>
           </div>
           <p class="brand-description">

--- a/docs/tos.html
+++ b/docs/tos.html
@@ -8,8 +8,8 @@ permalink: /tos/
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://unicons.iconscout.com/release/v4.0.8/css/line.css">
-  <link rel="stylesheet" href="style.css">
-  <script src="script.js" defer></script>
+  <link rel="stylesheet" href="/style.css">
+  <script src="/script.js" defer></script>
 
   <!-- SEO Meta Tags -->
   <title>服務條款 - DailyVal | 特戰英豪社群 APP</title>
@@ -48,7 +48,7 @@ permalink: /tos/
       <div class="header-container">
         <div class="header-brand">
           <a href="/" class="header-brand">
-            <img src="images/app icon.png" alt="DailyVal" class="brand-icon">
+            <img src="/images/app icon.png" alt="DailyVal" class="brand-icon">
             <div class="brand-text">
               <span class="brand-name">DailyVal</span>
               <span class="brand-tagline">每日特戰英豪</span>
@@ -262,7 +262,7 @@ permalink: /tos/
       <div class="footer-content">
         <div class="footer-brand">
           <div class="brand-logo">
-            <img src="images/app icon.png" alt="DailyVal">
+            <img src="/images/app icon.png" alt="DailyVal">
             <span class="brand-name">DailyVal</span>
           </div>
           <p class="brand-description">


### PR DESCRIPTION
- Convert all relative asset paths to absolute paths
- Change href="style.css" to href="/style.css" in all HTML files
- Change src="script.js" to src="/script.js" in all HTML files
- Change src="images/" to src="/images/" for all image references

This resolves the issue where clean URLs created subdirectories that broke relative asset loading (e.g., /support/ looking for /support/style.css).

🤖 Generated with [Claude Code](https://claude.ai/code)